### PR TITLE
Enable precise car spawning and filter telemetry

### DIFF
--- a/Assets/Driver/CarManager.cs
+++ b/Assets/Driver/CarManager.cs
@@ -193,7 +193,7 @@ public class CarManager : MonoBehaviour
         foreach (var kvp in carDictionary)
         {
             CarInfo carInfo = kvp.Value;
-            if (carInfo.carController == null || carInfo.frontFacingCamera == null || carInfo.autonomous)
+            if (carInfo.carController == null || carInfo.frontFacingCamera == null || !carInfo.autonomous)
                 continue;
 
             CarTelemetry telemetry = new CarTelemetry

--- a/Assets/TcpServerManager/CommandData.cs
+++ b/Assets/TcpServerManager/CommandData.cs
@@ -28,7 +28,26 @@ public class CommandData
     public bool autonomous;
     public CarControll carControll;
     public int requestedCarId;
+    public List<CarSpawnData> cars;
 
+}
+
+[Serializable]
+public class CarSpawnData
+{
+    public string name;
+    public float speed;
+    public float spawn_point;
+    public string prefab_name;
+    public float[] scale_Vektor;
+    public float[] rotation;
+    public float[] offset;
+    public float humanBehavior;
+    public WaitPoint[] waitingPoints;
+    public string[] waypoints;
+    public string layer;
+    public bool autonomous;
+    public int requestedCarId;
 }
 
 


### PR DESCRIPTION
## Summary
- Allow explicit control over spawn of cars with new `spawn_cars` and `spawn_random_cars` commands
- Prevent automatic vehicle spawning and only broadcast telemetry for agent-controlled cars
- Introduce `CarSpawnData` message structure for batching NPC spawns

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689a140d6e20832da5055ce2d0811eff